### PR TITLE
Feature/set default user

### DIFF
--- a/backend/api/v1/serializers.py
+++ b/backend/api/v1/serializers.py
@@ -30,6 +30,14 @@ class UserSerializer(serializers.ModelSerializer):
 		fields = ("email",)
 
 
+class UserTimezoneSerializer(serializers.ModelSerializer):
+	"""Сериализатор timezone пользователя."""
+
+	class Meta:
+		model = User
+		fields = ("timezone",)
+
+
 class MeSerializer(serializers.ModelSerializer):
 	"""Сериализатор Me пользователя."""
 
@@ -304,3 +312,9 @@ class HistorySerializer(serializers.ModelSerializer):
 	def create(self, validated_data: dict) -> History:
 		validated_data["user_id"] = self.context["request"].user
 		return super().create(validated_data)
+
+
+class BoolSerializer(serializers.Serializer):
+	"""Сериализатор bool значения."""
+
+	updated = serializers.BooleanField()

--- a/backend/api/v1/urls.py
+++ b/backend/api/v1/urls.py
@@ -11,6 +11,7 @@ from .views import (
 	TokenRefreshView,
 	TrainingView,
 	UpdateView,
+	UserDefaultView,
 )
 
 urlpatterns = (
@@ -25,4 +26,5 @@ urlpatterns = (
 	path("training/", TrainingView.as_view(), name="training"),
 	path("history/", HistoryView.as_view(), name="history"),
 	path("update/", UpdateView.as_view(), name="update"),
+	path("user-default/", UserDefaultView.as_view(), name="user-default"),
 )

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -7,9 +7,9 @@ from .constants import (
 	DEFAULT_AMOUNT_OF_SKIPS,
 	GENDER_CHOICES,
 	MAX_LEN_EMAIL,
+	MAX_LEN_GENDER,
 	MAX_LEN_NAME,
 	MAX_LEN_PASSWORD,
-	MAX_LEN_GENDER,
 	MAX_LEN_TIMEZONE,
 )
 from .managers import CustomUserManager

--- a/backend/utils/authcode.py
+++ b/backend/utils/authcode.py
@@ -51,6 +51,7 @@ class AuthCode:
 	def _send_code(self) -> None:
 		if not self._sender:
 			raise ValidationError("Невозможно отправить код: отправщик не установлен.")
+		print(self.code)
 		self._sender.send_code(self._user.email, self.code)
 
 	def set_sender(self, sender: MailSender) -> None:

--- a/backend/utils/authcode.py
+++ b/backend/utils/authcode.py
@@ -51,7 +51,6 @@ class AuthCode:
 	def _send_code(self) -> None:
 		if not self._sender:
 			raise ValidationError("Невозможно отправить код: отправщик не установлен.")
-		print(self.code)
 		self._sender.send_code(self._user.email, self.code)
 
 	def set_sender(self, sender: MailSender) -> None:

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -34,11 +34,7 @@ paths:
       - {}
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                Health: OK
-          description: ''
+          description: No response body
   /api/v1/history/:
     get:
       operationId: api_v1_history_list
@@ -136,14 +132,32 @@ paths:
   /api/v1/resend_code/:
     post:
       operationId: api_v1_resend_code_create
+      description: Повторная отправка кода
+      summary: Повторная отправка кода
       tags:
       - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/User'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/User'
+        required: true
       security:
       - jwtAuth: []
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: ''
   /api/v1/token/refresh/:
     post:
       operationId: api_v1_token_refresh_create
@@ -190,12 +204,23 @@ paths:
                   $ref: '#/components/schemas/Training'
           description: ''
   /api/v1/update/:
-    post:
-      operationId: api_v1_update_create
+    patch:
+      operationId: api_v1_update_partial_update
       description: Обновляет заморозки у пользователя и сохраняет часовой пояс
       summary: Обновляет заморозки у пользователя и сохраняет часовой пояс
       tags:
       - System
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedUserTimezone'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedUserTimezone'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedUserTimezone'
       security:
       - jwtAuth: []
       responses:
@@ -203,7 +228,7 @@ paths:
           content:
             application/json:
               schema:
-                updated: true
+                $ref: '#/components/schemas/Bool'
           description: ''
   /api/v1/user/:
     post:
@@ -231,6 +256,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+          description: ''
+  /api/v1/user-default/:
+    patch:
+      operationId: api_v1_user_default_partial_update
+      description: Очищает данные по тренировкам и ачивки пользователя
+      summary: Очищает данные по тренировкам и ачивки пользователя
+      tags:
+      - System
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bool'
           description: ''
 components:
   schemas:
@@ -288,6 +329,14 @@ components:
       required:
       - icon
       - title
+    Bool:
+      type: object
+      description: Сериализатор bool значения.
+      properties:
+        updated:
+          type: boolean
+      required:
+      - updated
     CustomTokenObtain:
       type: object
       properties:
@@ -471,6 +520,15 @@ components:
           type: string
           format: uri
           nullable: true
+    PatchedUserTimezone:
+      type: object
+      description: Сериализатор timezone пользователя.
+      properties:
+        timezone:
+          type: string
+          nullable: true
+          title: Часовой пояс пользователя
+          maxLength: 100
     Training:
       type: object
       description: Сериализатор тренировок.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ pytest = "^8.0.0"
 pytest-django = "^4.8.0"
 freezegun = "^1.4.0"
 pytest-repeat = "^0.9.3"
+isort = "^5.13.2"
 
 
 [build-system]


### PR DESCRIPTION
1. Написал эндпоинт для удаления всех историй/ачивок пользователя, а так же "обнуления" полей связанных с тренировками.
2.  Написал сериализаторы: `UserTimezoneSerializer` - валидирует `timezone` в `UpdateView` вместо метода `_validate_data`, `BoolSerializer` - нужен для корректного обозначения `response` в `Swagger` для эндпоинтов `update/` и `user-default/`.
3.  эндпоинт `update/` теперь `patch`.
4. Некоторые мелкие правки в `extend_schema_view` (нужно доделать).