### PR TITLE
Feature/correct timezone endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11"]
 
     services:
       postgres:

--- a/backend/api/v1/serializers.py
+++ b/backend/api/v1/serializers.py
@@ -314,7 +314,13 @@ class HistorySerializer(serializers.ModelSerializer):
 		return super().create(validated_data)
 
 
-class BoolSerializer(serializers.Serializer):
-	"""Сериализатор bool значения."""
+class ResponseUserDefaultSerializer(serializers.Serializer):
+	"""Сериализатор возвращаемого значения UserDefaultView."""
 
-	updated = serializers.BooleanField()
+	default = serializers.BooleanField()
+
+
+class ResponseUpdateSerializer(serializers.Serializer):
+	"""Сериализатор взрващаемого значения UpdateView."""
+
+	enough = serializers.BooleanField()

--- a/backend/api/v1/views.py
+++ b/backend/api/v1/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytz
 from django.contrib.auth import get_user_model
@@ -11,21 +11,24 @@ from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from running.models import Achievement, Day, History, UserAchievement
 from users.constants import DEFAULT_AMOUNT_OF_SKIPS
 from users.models import User as ClassUser
 from utils import authcode, mailsender, motivation_phrase, users
 from utils.achievements import AchievementUpdater
+from utils.amount_skips import counts_missed_days
 
 from .serializers import (
 	AchievementEndTrainingSerializer,
 	AchievementSerializer,
-	ResponseUserDefaultSerializer,
-	ResponseUpdateSerializer,
 	CustomTokenObtainSerializer,
 	HistorySerializer,
 	MeSerializer,
+	ResponseHealthCheckSerializer,
+	ResponseResendCodeSerializer,
+	ResponseUpdateSerializer,
+	ResponseUserDefaultSerializer,
 	TrainingSerializer,
 	UserSerializer,
 	UserTimezoneSerializer,
@@ -45,14 +48,23 @@ class HealthCheckView(APIView):
 	permission_classes = (AllowAny,)
 
 	@extend_schema(
+		responses={200: ResponseHealthCheckSerializer()},
 		summary="Проверка работы",
-		description="Проверка работы АПИ",
+		description="Проверка работы API",
 		tags=("System",),
 	)
 	def get(self, request):
 		return Response({"Health": "OK"})
 
 
+@extend_schema_view(
+	post=extend_schema(
+		responses={201: UserSerializer()},
+		summary="Создание пользователя",
+		description="Создание пользователя",
+		tags=("User",),
+	),
+)
 class RegisterUserView(APIView):
 	serializer_class = UserSerializer
 	permission_classes = (AllowAny,)
@@ -68,9 +80,10 @@ class RegisterUserView(APIView):
 
 @extend_schema_view(
 	post=extend_schema(
+		responses={201: ResponseResendCodeSerializer()},
 		summary="Повторная отправка кода",
 		description="Повторная отправка кода",
-		tags=("api",),
+		tags=("User",),
 	),
 )
 class ResendCodeView(APIView):
@@ -84,6 +97,14 @@ class ResendCodeView(APIView):
 		return Response({"result": "Код создан и отправлен"}, status=status.HTTP_201_CREATED)
 
 
+@extend_schema_view(
+	post=extend_schema(
+		responses={200: TokenRefreshSerializer()},
+		summary="Обновление токена",
+		description="Обновление токена",
+		tags=("User",),
+	),
+)
 class TokenRefreshView(APIView):
 	serializer_class = CustomTokenObtainSerializer
 	throttle_classes = (DurationCooldownRequestThrottle,)
@@ -92,31 +113,39 @@ class TokenRefreshView(APIView):
 	def post(self, request, format=None):
 		serializer = self.serializer_class(data=request.data)
 		if serializer.is_valid():
-			token_data = serializer.save()
+			token_data: dict = serializer.save()
+			token_data.pop("refresh")
 			return Response(token_data, status=status.HTTP_200_OK)
 		return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class MyInfoView(APIView):
+@extend_schema_view(
+	get=extend_schema(
+		responses={200: MeSerializer()},
+		summary="Отдаёт данные по пользователю",
+		description="Отдаёт данные по пользователю",
+		tags=("User",),
+	),
+	patch=extend_schema(
+		responses={200: MeSerializer()},
+		summary="Обновляет данные пользователя",
+		description="Обновляет данные пользователя",
+		tags=("User",),
+	),
+	put=extend_schema(exclude=True),
+	delete=extend_schema(
+		responses={204: MeSerializer()},
+		summary="Удаляет пользователя",
+		description="Удаляет пользователя",
+		tags=("User",),
+	),
+)
+class MyInfoView(generics.RetrieveUpdateDestroyAPIView):
 	serializer_class = MeSerializer
 
-	def get(self, request, *args, **kwargs):
-		user = request.user
-		serializer = self.serializer_class(user, context={"request": request})
-		return Response(serializer.data)
-
-	def patch(self, request, *args, **kwargs):
-		user = request.user
-		serializer = self.serializer_class(user, data=request.data, context={"request": request}, partial=True)
-		if serializer.is_valid():
-			serializer.save()
-			return Response(serializer.data)
-		return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-	def delete(self, request, *args, **kwargs):
-		user = request.user
-		user.delete()
-		return Response(status=status.HTTP_204_NO_CONTENT)
+	def get_object(self):
+		"""Отдаёт объект пользователя."""
+		return self.request.user
 
 
 @extend_schema_view(
@@ -234,18 +263,11 @@ class HistoryView(generics.ListCreateAPIView):
 		responses={200: ResponseUpdateSerializer()},
 		summary="Обновляет заморозки у пользователя и сохраняет часовой пояс",
 		description="Обновляет заморозки у пользователя и сохраняет часовой пояс",
-		tags=("System",),
+		tags=("User",),
 	),
 )
 class UpdateView(APIView):
 	serializer_class = UserTimezoneSerializer
-
-	def _get_date_activity(self, user: ClassUser, user_timezone: str) -> datetime:
-		"""Отдаёт дату последней активности в виде тренировки или заморозки."""
-		date_activity = max(
-			[date for date in [user.date_last_skips, user.last_completed_training.training_start] if date is not None]
-		)
-		return date_activity.astimezone(pytz.timezone(user_timezone))
 
 	def _updates_skip_data(
 		self, user: ClassUser, amount_of_skips: int, days_missed: int, date_day_ago: datetime
@@ -271,21 +293,17 @@ class UpdateView(APIView):
 		serializer.is_valid(raise_exception=True)
 		user_timezone = request.data.get("timezone")
 		response = Response({"enough": True}, status=status.HTTP_200_OK)
-		user = request.user
-		last_traning = user.last_completed_training
+		user: ClassUser = request.user
+		last_traning: History = user.last_completed_training
 
 		if not last_traning or last_traning.training_day.day_number == 100:
 			self._update_user_timezone_data(user, user_timezone)
 			return response
-
-		date_activity = self._get_date_activity(user, user_timezone)
-		amount_of_skips = user.amount_of_skips
-		date_day_ago = timezone.localtime(timezone=pytz.timezone(user_timezone)) - timedelta(days=1)
-		days_missed = (date_day_ago.date() - date_activity.date()).days
+		now = timezone.localtime(timezone=pytz.timezone(user_timezone))
+		days_missed, date_day_ago, amount_of_skips = counts_missed_days(user, user_timezone, now)
 		if days_missed <= 0:
 			self._update_user_timezone_data(user, user_timezone)
 			return response
-
 		user.timezone = user_timezone
 		if amount_of_skips >= days_missed:
 			self._updates_skip_data(user, amount_of_skips, days_missed, date_day_ago)
@@ -299,7 +317,7 @@ class UpdateView(APIView):
 		responses={200: ResponseUserDefaultSerializer()},
 		summary="Очищает данные по тренировкам и ачивки пользователя",
 		description="Очищает данные по тренировкам и ачивки пользователя",
-		tags=("System",),
+		tags=("User",),
 	),
 )
 class UserDefaultView(APIView):

--- a/backend/utils/amount_skips.py
+++ b/backend/utils/amount_skips.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timedelta
+
+import pytz
+
+from users.models import User
+
+
+def get_date_activity(user: User, user_timezone: str) -> datetime:
+	"""Отдаёт дату последней активности в виде тренировки или заморозки."""
+	date_activity: datetime = max(
+		[date for date in [user.date_last_skips, user.last_completed_training.training_start] if date is not None]
+	)
+	return date_activity.astimezone(pytz.timezone(user_timezone))
+
+
+def counts_missed_days(user: User, user_timezone: str, now: datetime) -> tuple[int, datetime, int]:
+	"""
+	Просчитывает кол-во пропущенных дней и возвращает:
+	    пропущенные дни, дату день назад, кол-во заморозок пользователя
+	"""
+	date_activity = get_date_activity(user, user_timezone)
+	amount_of_skips = user.amount_of_skips
+	date_day_ago = now - timedelta(days=1)
+	days_missed = (date_day_ago.date() - date_activity.date()).days
+	return days_missed, date_day_ago, amount_of_skips

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -25,7 +25,7 @@ paths:
   /api/v1/health/:
     get:
       operationId: api_v1_health_retrieve
-      description: Проверка работы АПИ
+      description: Проверка работы API
       summary: Проверка работы
       tags:
       - System
@@ -34,7 +34,11 @@ paths:
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseHealthCheck'
+          description: ''
   /api/v1/history/:
     get:
       operationId: api_v1_history_list
@@ -85,8 +89,10 @@ paths:
   /api/v1/me/:
     get:
       operationId: api_v1_me_retrieve
+      description: Отдаёт данные по пользователю
+      summary: Отдаёт данные по пользователю
       tags:
-      - api
+      - User
       security:
       - jwtAuth: []
       responses:
@@ -98,8 +104,10 @@ paths:
           description: ''
     patch:
       operationId: api_v1_me_partial_update
+      description: Обновляет данные пользователя
+      summary: Обновляет данные пользователя
       tags:
-      - api
+      - User
       requestBody:
         content:
           application/json:
@@ -122,20 +130,26 @@ paths:
           description: ''
     delete:
       operationId: api_v1_me_destroy
+      description: Удаляет пользователя
+      summary: Удаляет пользователя
       tags:
-      - api
+      - User
       security:
       - jwtAuth: []
       responses:
         '204':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Me'
+          description: ''
   /api/v1/resend_code/:
     post:
       operationId: api_v1_resend_code_create
       description: Повторная отправка кода
       summary: Повторная отправка кода
       tags:
-      - api
+      - User
       requestBody:
         content:
           application/json:
@@ -152,17 +166,19 @@ paths:
       - jwtAuth: []
       - {}
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/ResponseResendCode'
           description: ''
   /api/v1/token/refresh/:
     post:
       operationId: api_v1_token_refresh_create
+      description: Обновление токена
+      summary: Обновление токена
       tags:
-      - api
+      - User
       requestBody:
         content:
           application/json:
@@ -183,7 +199,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomTokenObtain'
+                $ref: '#/components/schemas/TokenRefresh'
           description: ''
   /api/v1/training/:
     get:
@@ -209,7 +225,7 @@ paths:
       description: Обновляет заморозки у пользователя и сохраняет часовой пояс
       summary: Обновляет заморозки у пользователя и сохраняет часовой пояс
       tags:
-      - System
+      - User
       requestBody:
         content:
           application/json:
@@ -233,8 +249,10 @@ paths:
   /api/v1/user/:
     post:
       operationId: api_v1_user_create
+      description: Создание пользователя
+      summary: Создание пользователя
       tags:
-      - api
+      - User
       requestBody:
         content:
           application/json:
@@ -251,7 +269,7 @@ paths:
       - jwtAuth: []
       - {}
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
@@ -263,7 +281,7 @@ paths:
       description: Очищает данные по тренировкам и ачивки пользователя
       summary: Очищает данные по тренировкам и ачивки пользователя
       tags:
-      - System
+      - User
       security:
       - jwtAuth: []
       responses:
@@ -521,9 +539,23 @@ components:
           nullable: true
           title: Часовой пояс пользователя
           maxLength: 100
+    ResponseHealthCheck:
+      type: object
+      description: Сериализатор возрващаемого значения HealthCheckView.
+      properties:
+        Health:
+          type: string
+          default: OK
+    ResponseResendCode:
+      type: object
+      description: Сериализатор возрващаемого значения ResendCodeView.
+      properties:
+        result:
+          type: string
+          default: Код создан и отправлен
     ResponseUpdate:
       type: object
-      description: Сериализатор взрващаемого значения UpdateView.
+      description: Сериализатор возрващаемого значения UpdateView.
       properties:
         enough:
           type: boolean
@@ -537,6 +569,18 @@ components:
           type: boolean
       required:
       - default
+    TokenRefresh:
+      type: object
+      properties:
+        access:
+          type: string
+          readOnly: true
+        refresh:
+          type: string
+          writeOnly: true
+      required:
+      - access
+      - refresh
     Training:
       type: object
       description: Сериализатор тренировок.

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -228,7 +228,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Bool'
+                $ref: '#/components/schemas/ResponseUpdate'
           description: ''
   /api/v1/user/:
     post:
@@ -271,7 +271,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Bool'
+                $ref: '#/components/schemas/ResponseUserDefault'
           description: ''
 components:
   schemas:
@@ -329,14 +329,6 @@ components:
       required:
       - icon
       - title
-    Bool:
-      type: object
-      description: Сериализатор bool значения.
-      properties:
-        updated:
-          type: boolean
-      required:
-      - updated
     CustomTokenObtain:
       type: object
       properties:
@@ -529,6 +521,22 @@ components:
           nullable: true
           title: Часовой пояс пользователя
           maxLength: 100
+    ResponseUpdate:
+      type: object
+      description: Сериализатор взрващаемого значения UpdateView.
+      properties:
+        enough:
+          type: boolean
+      required:
+      - enough
+    ResponseUserDefault:
+      type: object
+      description: Сериализатор возвращаемого значения UserDefaultView.
+      properties:
+        default:
+          type: boolean
+      required:
+      - default
     Training:
       type: object
       description: Сериализатор тренировок.

--- a/test/api_tests/token_generation_tests.py
+++ b/test/api_tests/token_generation_tests.py
@@ -46,9 +46,7 @@ def get_users_token(client, user):
 def test_correct_code_yields_token(get_users_token):
 	response = get_users_token
 	assert response.status_code == status.HTTP_200_OK
-	assert "refresh" in response.data
 	assert "access" in response.data
-	assert response.data["refresh"] != ""
 	assert response.data["access"] != ""
 
 


### PR DESCRIPTION
1. Добавил валидацию `timezone`, переделал валидации `date_last_skips`,  `training_start`(проверка на блокировку на самом деле не особо рабочая, т.к. у нас нет жёсткой валидации отправляемого дня).
2. Переделал эндпоинт установки `timezone`, убрал функционал, отвечающий за очистку данных тренировок, теперь он возвращает `bool`-значение хватило пользователю заморозок или нет.
3. Переделал `view` эндпоинта `me`.
4. Некоторые доработки документации.
5. Отовсюду убрал `refresh`-токен.